### PR TITLE
Fix SCSS class selector

### DIFF
--- a/src/app/features/navigation-screen/navigation-screen.component.scss
+++ b/src/app/features/navigation-screen/navigation-screen.component.scss
@@ -55,7 +55,7 @@
       color: var(--text-color-primary);
     }
   }
-  muted {
+  .muted {
     font-size: 0.8em;
     color: #999;
   }


### PR DESCRIPTION
## Summary
- hook SCSS rule to `.muted` class in navigation screen

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: Property 'title' does not exist on type 'AppComponent')*

------
https://chatgpt.com/codex/tasks/task_e_683faa041dbc8325b7b7686f4ba8e43f